### PR TITLE
MW-390: Expose every endpoint that oauth2 has and document them

### DIFF
--- a/src/main/java/org/openlmis/auth/security/TokenServicesConfiguration.java
+++ b/src/main/java/org/openlmis/auth/security/TokenServicesConfiguration.java
@@ -1,0 +1,60 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.auth.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.oauth2.provider.ClientDetailsService;
+import org.springframework.security.oauth2.provider.token.DefaultTokenServices;
+import org.springframework.security.oauth2.provider.token.TokenEnhancer;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+
+@Configuration
+public class TokenServicesConfiguration {
+
+  @Autowired
+  private TokenStore tokenStore;
+
+  @Autowired
+  @Qualifier("clientDetailsServiceImpl")
+  private ClientDetailsService clientDetailsService;
+
+  @Value("${token.validitySeconds}")
+  private Integer tokenValiditySeconds;
+
+  @Autowired
+  private TokenEnhancer tokenEnhancer;
+
+  /**
+   * Default token services bean initializer.
+   * @return custom token services
+   */
+  @Primary
+  @Bean
+  public DefaultTokenServices defaultTokenServices() {
+    DefaultTokenServices tokenServices = new CustomTokenServices();
+    tokenServices.setTokenStore(tokenStore);
+    tokenServices.setSupportRefreshToken(true);
+    tokenServices.setClientDetailsService(clientDetailsService);
+    tokenServices.setTokenEnhancer(tokenEnhancer);
+    tokenServices.setAccessTokenValiditySeconds(tokenValiditySeconds);
+    return tokenServices;
+  }
+}

--- a/src/main/java/org/openlmis/auth/web/CustomApprovalEndpoint.java
+++ b/src/main/java/org/openlmis/auth/web/CustomApprovalEndpoint.java
@@ -1,0 +1,50 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.auth.web;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.oauth2.provider.endpoint.WhitelabelApprovalEndpoint;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.SessionAttributes;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Controller for displaying the approval page for the authorization server. Other than using
+ * url prefix, it doesn't differ from the default one.
+ */
+@RestController
+@SessionAttributes("authorizationRequest")
+public class CustomApprovalEndpoint extends WhitelabelApprovalEndpoint {
+  private static final String PREFIX = "/api";
+
+  /**
+   * Displays approval page.
+   */
+  @RequestMapping("/api/oauth/confirm_access")
+  public ModelAndView getAccessConfirmation(Map<String, Object> model, HttpServletRequest request)
+      throws Exception {
+    String template = createTemplate(model, request)
+        .replace("/oauth/authorize", PREFIX + "/oauth/authorize");
+    if (request.getAttribute("_csrf") != null) {
+      model.put("_csrf", request.getAttribute("_csrf"));
+    }
+    return new ModelAndView(new SpelView(template), model);
+  }
+}

--- a/src/main/java/org/openlmis/auth/web/SpelView.java
+++ b/src/main/java/org/openlmis/auth/web/SpelView.java
@@ -1,0 +1,80 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.auth.web;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.context.expression.MapAccessor;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.springframework.util.PropertyPlaceholderHelper.PlaceholderResolver;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Simple String template renderer.
+ *
+ */
+class SpelView implements View {
+
+  private final String template;
+
+  private final String prefix;
+
+  private final SpelExpressionParser parser = new SpelExpressionParser();
+
+  private final StandardEvaluationContext context = new StandardEvaluationContext();
+
+  private PlaceholderResolver resolver;
+
+  public SpelView(String template) {
+    this.template = template;
+    this.prefix = new RandomValueStringGenerator().generate() + "{";
+    this.context.addPropertyAccessor(new MapAccessor());
+    this.resolver = name -> {
+      Expression expression = parser.parseExpression(name);
+      Object value = expression.getValue(context);
+      return value == null ? null : value.toString();
+    };
+  }
+
+  public String getContentType() {
+    return "text/html";
+  }
+
+  public void render(Map<String, ?> model, HttpServletRequest request, HttpServletResponse response)
+      throws Exception {
+    Map<String, Object> map = new HashMap<String, Object>(model);
+    String path = ServletUriComponentsBuilder.fromContextPath(request).build()
+        .getPath();
+    map.put("path", path == null ? "" : path);
+    context.setRootObject(map);
+    String maskedTemplate = template.replace("${", prefix);
+    PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper(prefix, "}");
+    String result = helper.replacePlaceholders(maskedTemplate, resolver);
+    result = result.replace(prefix, "${");
+    response.setContentType(getContentType());
+    response.getWriter().append(result);
+  }
+
+}

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -360,5 +360,82 @@ resourceTypes:
                               example: |
                                {"access_token":"35c1a202-02f3-470e-a011-bf209ee11de2","token_type":"bearer","expires_in":1799,"scope":"read write","referenceDataUserId":"35316636-6264-6331-2d34-3933322d3462"}
                   400:
-                     body:
-                         application/json:
+                      body:
+                          application/json:
+      /check_token:
+          post:
+              description: Check access token.
+              securedBy: [basic]
+              queryParameters:
+                  token:
+                      displayName: access_token
+                      description: OAuth2 access token
+                      type: string
+                      required: true
+                      repeat: false
+              responses:
+                  200:
+                      description: Token is valid.
+                      body:
+                          application/json:
+                              example: |
+                                {"aud":["notification","reports","auth","requisition","referencedata","fulfillment"],"user_name":"admin","referenceDataUserId":"35316636-6264-6331-2d34-3933322d3462","scope":["read","write"],"exp":1499877574,"authorities":["USER","ADMIN"],"client_id":"user-client"}
+                  400:
+                      body:
+                          application/json:
+                              example: |
+                                {"error":"invalid_token","error_description":"Token was not recognised"}
+      /authorize:
+          get:
+              description: Displays user approval page or performs redirection if the user allowed it previously.
+              securedBy: [basic]
+              queryParameters:
+                  response_type:
+                      description: Value MUST be set to "code".
+                      type: string
+                      required: true
+                      repeat: false
+                  client_id:
+                      description: The client identifier.
+                      type: string
+                      required: true
+                      repeat: false
+                  redirect_uri:
+                      description: Redirection Endpoint.
+                      type: string
+                      required: false
+                      repeat: false
+                  scope:
+                      description: The scope of the access request. If omitted all scopes will be granted.
+                      type: string
+                      required: false
+                      repeat: false
+                  state:
+                      description: An opaque value used by the client to maintain state between the request and callback. The authorization server includes this value when redirecting the user-agent back to the client. The parameter SHOULD be used for preventing cross-site request forgery.
+                      type: string
+                      required: false
+                      repeat: false
+              responses:
+                  200:
+                  302:
+                      description: Redirection to the client.
+          post:
+              description: Submit the authorization form and perform redirection to the client. Form data includes flags such as user_oauth_approval, scope.write and scope.read.
+              securedBy: [basic]
+              responses:
+                  200:
+                  302:
+                      description: Redirection to the client.
+      /confirm_access:
+          get:
+              description: Used to render approval form in the authorization server.
+              securedBy: [basic]
+              responses:
+                  200:
+                  500:
+      /error:
+          get:
+              description: Used to render errors in the authorization server.
+              securedBy: [basic]
+              responses:
+                  200:


### PR DESCRIPTION
This PR exposes all oauth2 endpoints so that it's possible to use implicit grant type. There was a problem with having Authorize endpoint under /api - the default form was hardcoded to use /oauth/authorize, so I had to provide a custom one (it only prepends /api to the url, but it's still a whitelabel page). We will probably want to use our own UI for approval requests in the future, but that would require further investigation as the /oauth/authorize endpoint only accepts resource owner credentials and not access_token query parameter. We will also want to somehow pass the authorization request session attributes to that UI page.