### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/auth/ExposedMessageSourceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/ExposedMessageSourceIntegrationTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles("test", "test-run")
 @SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 public class ExposedMessageSourceIntegrationTest {
 

--- a/src/integration-test/java/org/openlmis/auth/ExposedMessageSourceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/ExposedMessageSourceIntegrationTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("test", "test-run")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
 public class ExposedMessageSourceIntegrationTest {
 

--- a/src/integration-test/java/org/openlmis/auth/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/repository/BaseCrudRepositoryIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
-@ActiveProfiles("test", "test-run")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest<T extends Identifiable> {
 

--- a/src/integration-test/java/org/openlmis/auth/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/repository/BaseCrudRepositoryIntegrationTest.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(properties = "spring.main.allow-bean-definition-overriding=true")
-@ActiveProfiles("test")
+@ActiveProfiles("test", "test-run")
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest<T extends Identifiable> {
 

--- a/src/integration-test/java/org/openlmis/auth/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/web/BaseWebIntegrationTest.java
@@ -68,7 +68,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = "spring.main.allow-bean-definition-overriding=true")
-@ActiveProfiles("test")
+@ActiveProfiles("test", "test-run")
 @DirtiesContext
 public abstract class BaseWebIntegrationTest {
   private static final String BASE_URL = System.getenv("BASE_URL");

--- a/src/integration-test/java/org/openlmis/auth/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/auth/web/BaseWebIntegrationTest.java
@@ -68,7 +68,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = "spring.main.allow-bean-definition-overriding=true")
-@ActiveProfiles("test", "test-run")
+@ActiveProfiles({"test", "test-run"})
 @DirtiesContext
 public abstract class BaseWebIntegrationTest {
   private static final String BASE_URL = System.getenv("BASE_URL");

--- a/src/main/java/org/openlmis/auth/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/auth/TestDataInitializer.java
@@ -28,7 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
 


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.