### PR TITLE
[MW-1477] Lockout QA changes

### DIFF
--- a/src/main/java/org/openlmis/auth/dto/UserDto.java
+++ b/src/main/java/org/openlmis/auth/dto/UserDto.java
@@ -15,6 +15,7 @@
 
 package org.openlmis.auth.dto;
 
+import java.time.ZonedDateTime;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -36,6 +37,7 @@ public final class UserDto implements User.Importer, User.Exporter {
   private String password;
   private Boolean enabled;
   private boolean lockedOut;
+  private ZonedDateTime lastUnsuccessfulAuthenticationAttemptDate;
 
   /**
    * Creates UserDto object with given params.

--- a/src/main/java/org/openlmis/auth/service/UserService.java
+++ b/src/main/java/org/openlmis/auth/service/UserService.java
@@ -15,15 +15,18 @@
 
 package org.openlmis.auth.service;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.openlmis.auth.domain.UnsuccessfulAuthenticationAttempt;
 import org.openlmis.auth.domain.User;
 import org.openlmis.auth.dto.SaveBatchResultDto;
 import org.openlmis.auth.dto.UnlockResponseDto;
@@ -133,11 +136,19 @@ public class UserService {
    * @return matching auth users
    */
   public List<UserDto> getAuthUsers(Boolean lockedOut) {
+    Map<UUID, ZonedDateTime> lastAttemptByUserId = StreamSupport
+        .stream(attemptCounterRepository.findAll().spliterator(), false)
+        .collect(Collectors.toMap(
+            attempt -> attempt.getUser().getId(),
+            UnsuccessfulAuthenticationAttempt::getLastUnsuccessfulAuthenticationAttemptDate));
+
     return findAll().stream()
         .filter(user -> lockedOut == null || user.isLockedOut() == lockedOut)
         .map(user -> {
           UserDto dto = new UserDto(user.getId(), user.getUsername(), user.getEnabled());
           dto.setLockedOut(user.isLockedOut());
+          dto.setLastUnsuccessfulAuthenticationAttemptDate(
+              lastAttemptByUserId.get(user.getId()));
           return dto;
         })
         .collect(Collectors.toList());

--- a/src/test/java/org/openlmis/auth/domain/UserTest.java
+++ b/src/test/java/org/openlmis/auth/domain/UserTest.java
@@ -29,6 +29,7 @@ public class UserTest {
   private static final String PASSWORD_FIELD = "password";
   private static final String ENCODER_FIELD = "ENCODER";
   private static final String UUID_TYPE_FIELD = "UUID_TYPE";
+  private static final String LAST_ATTEMPT_DATE_FIELD = "lastUnsuccessfulAuthenticationAttemptDate";
 
   private UserDto importer;
   private User user = new UserDataBuilder().withPassword("oldPassword").build();
@@ -75,7 +76,8 @@ public class UserTest {
     UserDto exporter = new UserDto();
     user.export(exporter);
 
-    assertThat(exporter).isEqualToIgnoringGivenFields(user, ENCODER_FIELD, UUID_TYPE_FIELD);
+    assertThat(exporter).isEqualToIgnoringGivenFields(
+        user, ENCODER_FIELD, UUID_TYPE_FIELD, LAST_ATTEMPT_DATE_FIELD);
   }
 
   @Test

--- a/src/test/java/org/openlmis/auth/service/UserServiceTest.java
+++ b/src/test/java/org/openlmis/auth/service/UserServiceTest.java
@@ -185,7 +185,7 @@ public class UserServiceTest {
   public void shouldPopulateLastUnsuccessfulAuthenticationAttemptDate() {
     User locked = new UserDataBuilder().asLockedOut(true).build();
     UnsuccessfulAuthenticationAttempt attempt = new UnsuccessfulAuthenticationAttempt(locked);
-    ZonedDateTime attemptDate = attempt.getLastUnsuccessfulAuthenticationAttemptDate();
+    final ZonedDateTime attemptDate = attempt.getLastUnsuccessfulAuthenticationAttemptDate();
     when(userRepository.findAll()).thenReturn(Collections.singletonList(locked));
     when(attemptCounterRepository.findAll()).thenReturn(Collections.singletonList(attempt));
 

--- a/src/test/java/org/openlmis/auth/service/UserServiceTest.java
+++ b/src/test/java/org/openlmis/auth/service/UserServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -164,6 +165,7 @@ public class UserServiceTest {
     User locked = new UserDataBuilder().asLockedOut(true).build();
     User unlocked = new UserDataBuilder().asLockedOut(false).build();
     when(userRepository.findAll()).thenReturn(Arrays.asList(locked, unlocked));
+    when(attemptCounterRepository.findAll()).thenReturn(Collections.emptyList());
 
     List<UserDto> all = userService.getAuthUsers(null);
     assertEquals(2, all.size());
@@ -177,6 +179,20 @@ public class UserServiceTest {
     List<UserDto> unlockedOnly = userService.getAuthUsers(false);
     assertEquals(1, unlockedOnly.size());
     assertEquals(unlocked.getId(), unlockedOnly.get(0).getId());
+  }
+
+  @Test
+  public void shouldPopulateLastUnsuccessfulAuthenticationAttemptDate() {
+    User locked = new UserDataBuilder().asLockedOut(true).build();
+    UnsuccessfulAuthenticationAttempt attempt = new UnsuccessfulAuthenticationAttempt(locked);
+    ZonedDateTime attemptDate = attempt.getLastUnsuccessfulAuthenticationAttemptDate();
+    when(userRepository.findAll()).thenReturn(Collections.singletonList(locked));
+    when(attemptCounterRepository.findAll()).thenReturn(Collections.singletonList(attempt));
+
+    List<UserDto> users = userService.getAuthUsers(true);
+
+    assertEquals(1, users.size());
+    assertEquals(attemptDate, users.get(0).getLastUnsuccessfulAuthenticationAttemptDate());
   }
 
   @Test


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/MW-1477
Description:
Add `lastUnsuccessfulAuthenticationAttemptDate` to `UserDto` for use in the Lockouts tab.