### PR TITLE
Migrate SonarCloud analysis to Java 21 and drop axios from the Consul script

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -10,37 +10,29 @@ jobs:
     name: SonarCloud Analyze
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'zulu'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
       - name: Build with Docker Compose
         run: |
           curl -o .env -L https://raw.githubusercontent.com/OpenLMIS/openlmis-ref-distro/master/settings-sample.env
           docker compose -f docker-compose.builder.yml run builder
           sudo chown -R $(whoami) ./
           cp ./build/reports/jacoco/test/jacocoTestReport.xml report.xml
-          rm -rf ./build
+      - name: Resolve service version
+        id: version
+        run: echo "value=$(grep -E '^serviceVersion=' gradle.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
       - name: Analyze
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          sudo chown -R $(whoami) ./
-          ./gradlew sonarqube --info
+          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          args: -Dsonar.projectVersion=${{ steps.version.outputs.value }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upcoming Version (WIP)
 =================
 
 Improvements:
+* Fixed SonarCloud analysis failing on the deprecated Java 17 runtime by running it through the SonarQube scan action (on Java 21) instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
 * Stabilized consul registration and health checks
 * [MW-1476](https://openlmis.atlassian.net/browse/MW-1476): Add user lockout API and unlock endpoint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Upcoming Version (WIP)
 
 Improvements:
 * Fixed SonarCloud analysis failing on the deprecated Java 17 runtime by running it through the SonarQube scan action (on Java 21) instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
+* Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).
 * Stabilized consul registration and health checks
 * [MW-1476](https://openlmis.atlassian.net/browse/MW-1476): Add user lockout API and unlock endpoint
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 
 plugins {
     id "org.flywaydb.flyway" version "6.0.8"
-    id "org.sonarqube" version "3.3"
     id "com.moowork.node" version "1.2.0"
 }
 
@@ -176,17 +175,6 @@ jacocoTestReport {
 
 checkstyle {
     toolVersion = "8.12"
-}
-
-//NOTE: This plugin requires that this task be named 'sonarqube'. In fact, it is performing SonarCloud analysis.
-sonarqube {
-    properties {
-        property "sonar.projectKey", "OpenLMIS_openlmis-auth"
-        property "sonar.organization", "openlmis"
-        property "sonar.host.url", "https://sonarcloud.io"
-        property "sonar.java.source", "17"
-        property "sonar.coverage.jacoco.xmlReportPaths", "./report.xml"
-    }
 }
 
 pmd {

--- a/consul/package.json
+++ b/consul/package.json
@@ -4,7 +4,6 @@
   "description": "Registration script for OpenLMIS Service",
   "main": "registration.js",
   "dependencies": {
-    "axios": "^1.6.0",
     "command-line-args": "^5.2.1",
     "ip": "^1.1.8",
     "raml-parser": "~0.8.18",

--- a/consul/registration.js
+++ b/consul/registration.js
@@ -1,6 +1,6 @@
 const commandLineArgs = require('command-line-args');
 const raml = require('raml-parser');
-const axios = require('axios');
+const http = require('http');
 const uuid = require('uuid');
 const fs = require('fs');
 const ip = require('ip');
@@ -73,25 +73,68 @@ class ServiceConsulRegistrator {
     return Promise.all(promises);
   }
 
+  _request(method, url, data) {
+    return new Promise((resolve, reject) => {
+      const options = { method: method };
+      let body;
+      if (data !== undefined) {
+        if (typeof data === 'object') {
+          body = JSON.stringify(data);
+          options.headers = {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(body)
+          };
+        } else {
+          body = String(data);
+          options.headers = { 'Content-Length': Buffer.byteLength(body) };
+        }
+      }
+
+      const req = http.request(url, options, (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          let parsed = raw;
+          try {
+            parsed = raw ? JSON.parse(raw) : raw;
+          } catch (parseError) {
+            parsed = raw;
+          }
+          resolve({ status: res.statusCode, data: parsed });
+        });
+      });
+
+      req.on('error', reject);
+      if (body !== undefined) {
+        req.write(body);
+      }
+      req.end();
+    });
+  }
+
   async _requestWithRetry(method, endpoint, data) {
     let lastError;
     for (let i = 0; i < this.attempts; i++) {
       try {
-        const response = await axios({
-          method: method,
-          url: `${this.baseUrl}${endpoint}`,
-          data: data
-        });
+        const response = await this._request(method, `${this.baseUrl}${endpoint}`, data);
         if (response.status >= 200 && response.status < 300) {
           return response.data;
         }
+        // Non-2xx: do not retry client errors (<500), retry server errors.
+        const httpError = new Error(`Request to ${endpoint} failed with status ${response.status}`);
+        httpError.status = response.status;
+        if (response.status < 500) throw httpError;
+        lastError = httpError;
       } catch (err) {
+        // Propagate client errors immediately; retry network/server errors.
+        if (err.status && err.status < 500) throw err;
         lastError = err;
-        if (err.response && err.response.status < 500) throw err;
-
-        console.log(`Attempt ${i + 1}/${this.attempts} connecting to Consul failed. Retrying...`);
-        await sleep(this.attemptTimeout);
       }
+
+      console.log(`Attempt ${i + 1}/${this.attempts} connecting to Consul failed. Retrying...`);
+      await sleep(this.attemptTimeout);
     }
     throw lastError;
   }

--- a/docker-compose.builder.yml
+++ b/docker-compose.builder.yml
@@ -14,22 +14,6 @@ services:
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
     env_file: .env
 
-  sonar:
-    image: openlmis/dev:10
-    links:
-      - db
-      - log
-    volumes:
-      - '.:/app'
-    entrypoint:
-      - 'gradle'
-    command:
-      - 'clean'
-      - 'sonarqube'
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.daemon=false'
-    env_file: .env
-
   demo-data:
     image: openlmis/dev:10
     links:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.projectKey=OpenLMIS_openlmis-auth
+sonar.organization=openlmis
+
+# Sources and tests
+sonar.sources=src/main/java,src/main/resources
+sonar.tests=src/test/java,src/integration-test/java
+
+# Java analysis inputs — classes compiled by the Docker build (docker-compose.builder.yml)
+sonar.java.binaries=build/classes/java/main
+sonar.java.source=17
+
+# Coverage — JaCoCo XML produced by the Docker build, copied to report.xml in the workflow
+sonar.coverage.jacoco.xmlReportPaths=report.xml


### PR DESCRIPTION
This PR bundles two BE-wide maintenance changes into one PR (BE builds take hours, so we batch them per the team decision).

## 1. Migrate SonarCloud analysis to Java 21

### Why
SonarCloud Cloud dropped support for running analysis on Java 17, which broke the pipeline. The `org.sonarqube` 3.3 plugin runs the scanner inside the Gradle JVM, and Gradle 4.10.3 can't run on Java 21 — so the scanner couldn't be moved to a supported Java version in place.

### What
Decouple the analysis from Gradle. Build, tests and the JaCoCo report stay in the Docker build; the analysis now runs via `SonarSource/sonarqube-scan-action@v6`, which provisions a Java 21 runtime for the scanner engine.

- Run analysis via `sonarqube-scan-action@v6` instead of `./gradlew sonarqube`
- Add `sonar-project.properties` reproducing the Gradle plugin's scope: sources `src/main/java` + `src/main/resources`, tests `src/test/java` + `src/integration-test/java`, `sonar.java.source=17`, JaCoCo coverage
- Pass `sonar.projectVersion` from `gradle.properties` `serviceVersion` so New Code (Previous version) is tracked correctly, as the Gradle plugin used to do
- Stop deleting `./build` so `sonar.java.binaries` finds the compiled classes
- Remove the now-unused `org.sonarqube` Gradle plugin, the `sonarqube {}` block and the dead `sonar` service in `docker-compose.builder.yml`
- Bump checkout/setup-java/cache actions to v4; drop the redundant runner JDK step

## 2. Drop the axios dependency from the Consul registration script

### Why
axios carries a recurring stream of security advisories. The registration script only makes a few HTTP calls to the internal Consul agent, so it doesn't need a third-party HTTP client.

### What
Replace axios with the native Node `http` client, mirroring the approach already taken in the UI repos and in openlmis-stockmanagement.

- Remove `axios` from `consul/package.json`
- Rewrite the request helper in `consul/registration.js` to use `http.request`; the request/retry behaviour is preserved
- `consul/config.json` is untouched (it is service-specific)

## Notes
- Build, tests and coverage are unchanged — only the analysis step is affected.
- `sonar.java.libraries` is not set (dependency jars live inside the Docker build), so expect a lower-precision warning for a subset of Java rules.
