### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ repositories {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.springframework.boot:spring-boot-starter-security"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"

--- a/src/main/java/org/openlmis/auth/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/auth/security/ResourceServerSecurityConfiguration.java
@@ -79,6 +79,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
         .authorizeRequests()
         .antMatchers(
             "/actuator/health",
+            "/actuator/prometheus",
             "/api/users/auth/forgotPassword",
             "/api/users/auth/changePassword",
             "/webjars/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,8 @@ spring.jpa.show-sql=false
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoints.web.exposure.include=health
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
 
 server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.rename-on-rotate=true


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM and HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring).

Changes:
- build.gradle: add io.micrometer:micrometer-registry-prometheus (actuator starter already present on master).
- application.properties: enable and expose the prometheus actuator endpoint (management.endpoint.prometheus.enabled=true; added to management.endpoints.web.exposure.include, which sets enabled-by-default=false).
- ResourceServerSecurityConfiguration: permit /actuator/prometheus (same treatment as the existing /actuator/health). auth has three stacked security chains; actuator paths fall under the resource-server chain's /** catch-all, so the permit belongs there.

Security: /actuator/prometheus is permitted unauthenticated on the app port, mirroring /actuator/health. In the Malawi deployment service ports are not host-published and nginx only routes /api/*, so the endpoint is reachable only on the internal network where Alloy scrapes it.

Verified: builds, boots, and GET /actuator/prometheus returns 200 with JVM/HTTP metrics. A companion hotfix branch rel-4.3.5-hotfix.1 carries the same activation (plus serviceVersion=4.3.5-hotfix.1) on the deployed 4.3.5 line.